### PR TITLE
Changed unzip to always use 0755 for directories

### DIFF
--- a/libraries/helpers/unzip.go
+++ b/libraries/helpers/unzip.go
@@ -39,11 +39,11 @@ func Unzip(zipFilePath, targetDir string) error {
     path := filepath.Join(targetDir, file.Name)
 
     if file.FileInfo().IsDir() {
-      if err := os.MkdirAll(path, file.Mode()); err != nil {
+      if err := os.MkdirAll(path, 0755); err != nil {
         return err
       }
     } else {
-      if err := os.MkdirAll(filepath.Dir(path), file.Mode()); err != nil {
+      if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
         return err
       }
       file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())


### PR DESCRIPTION
This fixes #1. The issue was that creating parent directories on line 46 would use the permissions of the contained file, which did not have the execute bit set. Thus you couldn't enter the directory!

The change on line 42 is most likely unnecessary, but in the interests of consistent permissions I made the change there as well.
